### PR TITLE
Extracted CLI parsing to `cli.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ No dependencies outside the Python Standard Library needed.
 
 ## Usage
 
-    python3 main.py [filename]...
+    python3 cli.py [filename]...
 
 **Must use Python 3.3 for proper character encoding support.**
 

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+#-*- encoding: utf-8
+"""
+Start a Suplemon instance in the current window
+"""
+
+import argparse
+
+from main import App, __version__
+
+
+def main():
+    """Handle CLI invocation"""
+    # Parse our CLI arguments
+    parser = argparse.ArgumentParser(description="Console text editor with multi cursor support")
+    parser.add_argument("filenames", metavar="filename", type=str, nargs="*", help="Files to load into Suplemon")
+    parser.add_argument("--version", action="version", version=__version__)
+    args = parser.parse_args()
+
+    # Generate and start our application
+    app = App(filenames=args.filenames)
+    app.init()
+
+    # Output log info
+    if app.config["app"]["debug"]:
+        app.logger.output()
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 #-*- encoding: utf-8
 
 """
@@ -21,7 +20,13 @@ from editor import *
 from file import *
 
 class App:
-    def __init__(self):
+    def __init__(self, filenames=None):
+        """
+        Handle App initialization
+
+        :param list filenames: Names of files to load initially
+        :param str filenames[*]: Path to a file to load
+        """
         self.version = __version__
         self.inited = 0
         self.running = 0
@@ -64,6 +69,9 @@ class App:
         # Load extension modules
         self.modules = modules.ModuleLoader(self)
         self.modules.load()
+
+        # Save filenames for later
+        self.filenames = filenames
 
         # Indicate that windows etc. have been created.
         self.inited = 1
@@ -474,10 +482,8 @@ class App:
 
     def load_files(self):
         """Try to load all files specified in arguments."""
-        #TODO: Maybe use argparse for this
-        if len(sys.argv) > 1:
-            names = sys.argv[1:]
-            for name in names:
+        if self.filenames:
+            for name in self.filenames:
                 if self.file_is_open(name): continue
                 if self.open_file(name):
                     loaded = True
@@ -507,11 +513,3 @@ class App:
         # Set markdown as the default file type
         file.editor.set_file_extension("md")
         return file
-
-if __name__ == "__main__":
-    """Only run the app if it's run directly (not imported)."""
-    app = App()
-    app.init()
-    # Output log info
-    if app.config["app"]["debug"]:
-        app.logger.output()


### PR DESCRIPTION
As discussed in #50, this is a good low hanging fruit to get started on. This PR extracts all `sys.argv`/CLI interactions to a `cli.py` making testing `App` simpler.

In this PR:

- Removed `__name__` and `sys.argv` interactions from `main.py`
- Removed `a+x` permissions from `main.py`
- Added `filenames` support to `App.__init__`
- Added `cli.py`
    - I wanted to place this in `bin/cli.py` but then relative imports weren't working out due to a lack of `setup.py` and it was turning into a rabbit hole
- Updated documentation to run `python3 cli.py`

**Notes:**

This PR doesn't contain a `setup.py` nor `entry points` bindings because there were details I didn't know (e.g. `author email`, preferred keywords, classifiers). Here is the typical template I use for my `setup.py`:

https://github.com/twolfson/grunt-init-python/blob/2.1.0/root/setup.py