### PR TITLE
Highlight bugfix

### DIFF
--- a/suplemon/lexer.py
+++ b/suplemon/lexer.py
@@ -19,6 +19,9 @@ class Lexer:
         :return:
         """
         if lex is None:
+            if not type(code) is str:
+                # if not suitable lexer is found, return decoded code
+                code = code.decode("utf-8")
             return (("global", code),)
 
         words = pygments.lex(code, lex)

--- a/suplemon/viewer.py
+++ b/suplemon/viewer.py
@@ -330,7 +330,7 @@ class Viewer:
         :param x_offset: Offset from the left edge of screen. Currently same as x position.
         :param max_len: Maximum amount of chars that will fit on screen.
         """
-        if pygments and self.app.config["editor"]["show_highlighting"]:
+        if pygments and self.app.config["editor"]["show_highlighting"] and self.pygments_syntax:
             self.render_line_pygments(line, pos, x_offset, max_len)
         elif self.app.config["editor"]["show_line_colors"]:
             self.render_line_linelight(line, pos, x_offset, max_len)


### PR DESCRIPTION
After opening several files with Suplemon I found that the viewer failed rendering lines when the file type is not supported by Pygments(with the error TypeError: expected bytes, bytearray or buffer compatible object). That is because lexer returns raw bytes when no Pygments lexer is provided but replace_whitespace only accepts strings. This PR fixed the bug. Also, using linelight to render files that are not supported by Pygments is a better choice. 