### PR TITLE
Moved to use BufferingHandler and added RotatingFileHandler

### DIFF
--- a/suplemon/cli.py
+++ b/suplemon/cli.py
@@ -38,7 +38,8 @@ def main():
 
     # Output log info
     if app.debug:
-        app.logger_handler.output()
+        for logger_handler in app.logger.handlers:
+            logger_handler.close()
 
 if __name__ == "__main__":
     main()

--- a/suplemon/logger.py
+++ b/suplemon/logger.py
@@ -1,21 +1,68 @@
 """
 Basic logging to delay printing until curses is unloaded.
 """
+from __future__ import print_function
+import os
 import logging
+from logging.handlers import BufferingHandler, RotatingFileHandler
+import sys
 
 
-class LoggingHandler(logging.Handler):
-    def __init__(self):
-        logging.Handler.__init__(self)
-        self.messages = []
+# Define an mix of BufferingHandler and MemoryHandler which store records internally and flush on `close`
+# https://docs.python.org/3.3/library/logging.handlers.html#logging.handlers.BufferingHandler
+# https://docs.python.org/3.3/library/logging.handlers.html#logging.handlers.MemoryHandler
+class BufferingTargetHandler(BufferingHandler):
+    # Set up capacity and target for MemoryHandler
+    def __init__(self, capacity, fd_target):
+        """
+        :param int capacity: Amount of records to store in memory
+            https://github.com/python/cpython/blob/3.3/Lib/logging/handlers.py#L1161-L1176
+        :param object fd_target: File descriptor to write output to (e.g. `sys.stdout`)
+        """
+        # Call our BufferingHandler init
+        super(BufferingTargetHandler, self).__init__(capacity)
 
-    def emit(self, record):
-        msg = self.format(record)
-        self.messages.append(msg)
+        # Save target for later
+        self._fd_target = fd_target
 
     def close(self):
-        logging.Handler.close(self)
+        """Upon `close`, flush our internal info to the target"""
+        # Flush our buffers to the target
+        # https://github.com/python/cpython/blob/3.3/Lib/logging/handlers.py#L1185
+        # https://github.com/python/cpython/blob/3.3/Lib/logging/handlers.py#L1241-L1256
+        self.acquire()
+        try:
+            for record in self.buffer:
+                msg = self.format(record)
+                print(msg, file=self._fd_target)
+        finally:
+            self.release()
 
-    def output(self):
-        for message in self.messages:
-            print(message)
+        # Then, run our normal close actions
+        super(BufferingTargetHandler, self).close()
+
+
+# Initialize logging
+logging.basicConfig(level=logging.NOTSET)
+logger = logging.getLogger()
+logger.handlers = []
+
+# Generate and configure handlers
+log_filepath = os.path.join(os.path.expanduser("~"), ".config", "suplemon", "output.log")
+logger_handlers = [
+    # Output up to 4MB of records to `~/.config/suplemon/output.log` for live debugging
+    # https://docs.python.org/3.3/library/logging.handlers.html#logging.handlers.RotatingFileHandler
+    # DEV: We use append mode to prevent erasing out logs
+    # DEV: We use 1 backup count since it won't truncate otherwise =/
+    RotatingFileHandler(log_filepath, mode="a", maxBytes=(4 * 1024 * 1024), backupCount=1),
+    # Buffer 64k records in memory at a time
+    BufferingTargetHandler(64 * 1024, fd_target=sys.stderr),
+]
+fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+logger_formatter = logging.Formatter(fmt)
+for logger_handler in logger_handlers:
+    logger_handler.setFormatter(logger_formatter)
+
+# Save handlers for our logger
+for logger_handler in logger_handlers:
+    logger.addHandler(logger_handler)

--- a/suplemon/main.py
+++ b/suplemon/main.py
@@ -8,7 +8,6 @@ __version__ = "0.1.41"
 
 import os
 import sys
-import logging
 
 from . import ui
 from . import modules
@@ -16,7 +15,7 @@ from . import themes
 from . import helpers
 
 from .file import File
-from .logger import LoggingHandler
+from .logger import logger
 from .config import Config
 from .editor import Editor
 
@@ -69,15 +68,8 @@ class App:
             "toggle_fullscreen": self.toggle_fullscreen,
         }
 
-        # Initialize logging
-        logging.basicConfig(level=logging.NOTSET)
-        self.logger = logging.getLogger()
-        self.logger.handlers = []
-        self.logger_handler = LoggingHandler()
-        fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        self.logger_formatter = logging.Formatter(fmt)
-        self.logger_handler.setFormatter(self.logger_formatter)
-        self.logger.addHandler(self.logger_handler)
+        # Bind our logger
+        self.logger = logger
         self.logger.info("Starting Suplemon...")
 
     def init(self):


### PR DESCRIPTION
I was digging around the code some more and noticed there is no way to view logs as they are occurring live. To remedy that, I took the following steps:

- Bring `logger` setup into `logger.py`
- Moved `LoggerHandler` on top of `BufferingHandler` so we can keep things more inline with Python
    - Bonus: We get a hard limit on our buffer so we can't run into memory issues due to long running applications
- Added `RotatingFileHandler` which outputs to `~/.config/suplemon/output.log`
    - Now we can use `tail -f ~/.config/suplemon/output.log` while performing development (until we get something more full-fledged like Sublime's terminal