### PR TITLE
Added release.sh to simplify releases

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Exit on first error
+set -e
+
+# Parse our CLI arguments
+version="$1"
+if test "$version" = ""; then
+  echo "Expected a version to be provided to \`release.sh\` but none was provided." 1>&2
+  echo "Usage: $0 [version] # (e.g. $0 1.0.0)" 1>&2
+  exit 1
+fi
+
+# Bump the version via regexp
+sed -E "s/^(__version__ = \")[0-9]+\.[0-9]+\.[0-9]+(\")$/\1$version\2/" suplemon/main.py --in-place
+
+# Verify our version made it into the file
+if ! grep "$version" suplemon/main.py &> /dev/null; then
+  echo "Expected \`__version__\` to update via \`sed\` but it didn't" 1>&2
+  exit 1
+fi
+
+# Commit the change
+git add suplemon/main.py
+git commit -a -m "Release $version"
+
+# Tag the release
+git tag "$version"
+
+# Publish the release to GitHub
+git push
+git push --tags
+
+# Publish the release to PyPI
+python setup.py sdist --formats=gztar,zip upload


### PR DESCRIPTION
This PR was originally opened as #124 but it was pointing to the wrong branch

-----------------------------

Now that we are publishing the PyPI, the release process is becoming more complex. At this stage, I typically like to automate things to make sure I don't miss a step and have to re-release all over.

In this PR:

- Added `release.sh`
    - Takes care of bumping `__version__`, creating a `git commit`, creating a `git tag`, pushing new commit and tag, and publishing `.gz.tar` and `.zip` to PyPI