### PR TITLE
Adds a color map to linelight to avoid hard coded color codes

### DIFF
--- a/suplemon/linelight/color_map.py
+++ b/suplemon/linelight/color_map.py
@@ -1,0 +1,9 @@
+color_map = {
+    "red": 1,
+    "green": 2,
+    "yellow": 3,
+    "blue": 4,
+    "magenta": 5,
+    "cyan": 6,
+    "white": 7
+}

--- a/suplemon/linelight/css.py
+++ b/suplemon/linelight/css.py
@@ -1,4 +1,5 @@
 from suplemon import helpers
+from suplemon.linelight.color_map import color_map
 
 
 class Syntax:
@@ -6,16 +7,16 @@ class Syntax:
         return ("/*", "*/")
 
     def get_color(self, raw_line):
-        color = 7
+        color = color_map["white"]
         line = raw_line.strip()
         if helpers.starts(line, "@import"):
-            color = 4    # Blue
+            color = color_map["blue"]
         elif helpers.starts(line, "$"):
-            color = 2    # Green
+            color = color_map["green"]
         elif helpers.starts(line, "/*") or helpers.ends(line, "*/"):
-            color = 5    # Magenta
+            color = color_map["magenta"]
         elif helpers.starts(line, "{") or helpers.ends(line, "}") or helpers.ends(line, "{"):
-            color = 6    # Cyan
+            color = color_map["cyan"]
         elif helpers.ends(line, ";"):
-            color = 3    # Yellow
+            color = color_map["yellow"]
         return color

--- a/suplemon/linelight/html.py
+++ b/suplemon/linelight/html.py
@@ -1,4 +1,5 @@
 from suplemon import helpers
+from suplemon.linelight.color_map import color_map
 
 
 class Syntax:
@@ -6,14 +7,14 @@ class Syntax:
         return ("<!--", "-->")
 
     def get_color(self, raw_line):
-        color = 7
+        color = color_map["white"]
         line = raw_line.strip()
         if helpers.starts(line, ["#", "//", "/*", "*/", "<!--"]):
-            color = 5    # Magenta
+            color = color_map["magenta"]
         elif helpers.ends(line, ["*/", "-->"]):
-            color = 5    # Magenta
+            color = color_map["magenta"]
         elif helpers.starts(line, "<"):
-            color = 6    # Cyan
+            color = color_map["cyan"]
         elif helpers.ends(line, ">"):
-            color = 6    # Cyan
+            color = color_map["cyan"]
         return color

--- a/suplemon/linelight/js.py
+++ b/suplemon/linelight/js.py
@@ -1,4 +1,5 @@
 from suplemon import helpers
+from suplemon.linelight.color_map import color_map
 
 
 class Syntax:
@@ -6,18 +7,18 @@ class Syntax:
         return ("//", "")
 
     def get_color(self, raw_line):
-        color = 7
+        color = color_map["white"]
         line = raw_line.strip()
         if helpers.starts(line, ["import", "from"]):
-            color = 4    # Blue
+            color = color_map["blue"]
         elif helpers.starts(line, "function"):
-            color = 6    # Cyan
+            color = color_map["cyan"]
         elif helpers.starts(line, ["return"]):
-            color = 1    # Red
+            color = color_map["red"]
         elif helpers.starts(line, "this."):
-            color = 6    # Cyan
+            color = color_map["cyan"]
         elif helpers.starts(line, ["//", "/*", "*/", "*"]):
-            color = 5    # Magenta
+            color = color_map["magenta"]
         elif helpers.starts(line, ["if", "else", "for ", "while ", "continue", "break"]):
-            color = 3    # Yellow
+            color = color_map["yellow"]
         return color

--- a/suplemon/linelight/json.py
+++ b/suplemon/linelight/json.py
@@ -1,4 +1,5 @@
 from suplemon import helpers
+from suplemon.linelight.color_map import color_map
 
 
 class Syntax:
@@ -6,10 +7,10 @@ class Syntax:
         return ("", "")
 
     def get_color(self, raw_line):
-        color = 7
+        color = color_map["white"]
         line = raw_line.strip()
         if helpers.starts(line, ["{", "}"]):
-            color = 3    # Blue
+            color = color_map["yellow"]
         elif helpers.starts(line, "\""):
-            color = 2    # Green
+            color = color_map["green"]
         return color

--- a/suplemon/linelight/lua.py
+++ b/suplemon/linelight/lua.py
@@ -1,8 +1,10 @@
+from suplemon.linelight.color_map import color_map
+
 
 class Syntax:
     def get_comment(self):
         return ("-- ", "")
 
     def get_color(self, raw_line):
-        color = 7
+        color = color_map["white"]
         return color

--- a/suplemon/linelight/md.py
+++ b/suplemon/linelight/md.py
@@ -1,4 +1,5 @@
 from suplemon import helpers
+from suplemon.linelight.color_map import color_map
 
 
 class Syntax:
@@ -6,14 +7,14 @@ class Syntax:
         return ("", "")
 
     def get_color(self, raw_line):
-        color = 7
+        color = color_map["white"]
         line = raw_line.strip()
         if helpers.starts(line, ["*", "-"]):  # List
-            color = 6    # Cyan
+            color = color_map["cyan"]
         elif helpers.starts(line, "#"):  # Header
-            color = 2    # Green
+            color = color_map["green"]
         elif helpers.starts(line, ">"):  # Item desription
-            color = 3    # Yellow
+            color = color_map["yellow"]
         elif helpers.starts(raw_line, "    "):  # Code
-            color = 5    # Magenta
+            color = color_map["magenta"]
         return color

--- a/suplemon/linelight/php.py
+++ b/suplemon/linelight/php.py
@@ -1,4 +1,5 @@
 from suplemon import helpers
+from suplemon.linelight.color_map import color_map
 
 
 class Syntax:
@@ -6,22 +7,22 @@ class Syntax:
         return ("//", "")
 
     def get_color(self, raw_line):
-        color = 7
+        color = color_map["white"]
         line = raw_line.strip()
         keywords = ["if", "else", "finally", "try", "catch", "foreach",
                     "while", "continue", "pass", "break"]
         if helpers.starts(line, ["include", "require"]):
-            color = 4    # Blue
+            color = color_map["blue"]
         elif helpers.starts(line, ["class", "public", "private", "function"]):
-            color = 2    # Green
+            color = color_map["green"]
         elif helpers.starts(line, "def"):
-            color = 6    # Cyan
+            color = color_map["cyan"]
         elif helpers.starts(line, ["return"]):
-            color = 1    # Red
+            color = color_map["red"]
         elif helpers.starts(line, "$"):
-            color = 6    # Cyan
+            color = color_map["cyan"]
         elif helpers.starts(line, ["#", "//", "/*", "*/"]):
-            color = 5    # Magenta
+            color = color_map["magenta"]
         elif helpers.starts(line, keywords):
-            color = 3    # Yellow
+            color = color_map["yellow"]
         return color

--- a/suplemon/linelight/py.py
+++ b/suplemon/linelight/py.py
@@ -1,4 +1,5 @@
 from suplemon import helpers
+from suplemon.linelight.color_map import color_map
 
 
 class Syntax:
@@ -6,22 +7,22 @@ class Syntax:
         return ("# ", "")
 
     def get_color(self, raw_line):
-        color = 7
+        color = color_map["white"]
         line = raw_line.strip()
         keywords = ["if", "elif", "else", "finally", "try", "except",
                     "for ", "while ", "continue", "pass", "break"]
         if helpers.starts(line, ["import", "from"]):
-            color = 4    # Blue
+            color = color_map["blue"]
         elif helpers.starts(line, "class"):
-            color = 2    # Green
+            color = color_map["green"]
         elif helpers.starts(line, "def"):
-            color = 6    # Cyan
+            color = color_map["cyan"]
         elif helpers.starts(line, ["return", "yield"]):
-            color = 1    # Red
+            color = color_map["red"]
         elif helpers.starts(line, "self."):
-            color = 6    # Cyan
+            color = color_map["cyan"]
         elif helpers.starts(line, ["#", "//", "\"", "'", ":"]):
-            color = 5    # Magenta
+            color = color_map["magenta"]
         elif helpers.starts(line, keywords):
-            color = 3    # Yellow
+            color = color_map["yellow"]
         return color

--- a/suplemon/viewer.py
+++ b/suplemon/viewer.py
@@ -6,15 +6,16 @@ Text viewer component subclassed by Editor.
 import os
 import re
 import sys
-import imp
 import curses
 import logging
+import importlib
 
 from . import helpers
 
 from .line import Line
 from .cursor import Cursor
 from .themes import scope_to_pair
+import suplemon.linelight  # NOQA
 
 try:
     import pygments.lexers
@@ -900,9 +901,10 @@ class Viewer(BaseViewer):
         filename = ext + ".py"
         path = os.path.join(curr_path, "linelight", filename)
         module = False
+        syntax_module_name = ".{}".format(ext)
         if os.path.isfile(path):
             try:
-                module = imp.load_source(ext, path)
+                module = importlib.import_module(syntax_module_name, "suplemon.linelight")
             except:
                 self.logger.error("Failed to load syntax file '{0}'!".format(path), exc_info=True)
         else:


### PR DESCRIPTION
Adds a color map to linelight to avoid hard coded color codes in the syntax modules.
Does fix the mismatch in json.py line 12 but leaves the color as before (as defined by the code not the comment)