### PR TITLE
Add support for the MacOS native pasteboard via pbcopy/pbpaste.

### DIFF
--- a/suplemon/main.py
+++ b/suplemon/main.py
@@ -18,7 +18,7 @@ from .logger import logger
 from .config import Config
 from .editor import Editor
 
-__version__ = "0.1.58"
+__version__ = "0.1.59"
 
 
 class App:


### PR DESCRIPTION
MacOS doesn't have great support for xsel but does have somewhat equivalent functionality in pbcopy/pbpaste. This PR checks for the existence of pbcopy/pbpaste and uses it to support the native MacOS clipboard.