### PR TITLE
config.py: merge all the default config into user config

### DIFF
--- a/suplemon/config.py
+++ b/suplemon/config.py
@@ -127,14 +127,18 @@ class Config:
 
     def merge_defaults(self, config):
         """Fill any missing config options with defaults."""
-        for prim_key in self.defaults.keys():
-            curr_item = self.defaults[prim_key]
-            if prim_key not in config.keys():
-                config[prim_key] = dict(curr_item)
+        return self._merge_defaults(self.defaults, config)
+
+    def _merge_defaults(self, defaults, config):
+        """Recursivley merge two dicts."""
+        for key in defaults.keys():
+            item = defaults[key]
+            if key not in config.keys():
+                config[key] = item
                 continue
-            for sec_key in curr_item.keys():
-                if sec_key not in config[prim_key].keys():
-                    config[prim_key][sec_key] = curr_item[sec_key]
+            if not isinstance(item, dict):
+                continue
+            config[key] = self._merge_defaults(item, config[key])
         return config
 
     def load_config_file(self, path):


### PR DESCRIPTION
Merge default and user config recursively. This allows to have more than two dict layers in configs.
Only dicts will be merged, lists (and everything else) will be used from user config and only if the user config does not provide it the default value will be used instead.