### PR TITLE
config.py: merge default module configs into user config

### DIFF
--- a/suplemon/config.py
+++ b/suplemon/config.py
@@ -105,6 +105,17 @@ class Config:
         self.defaults = config
         return True
 
+    def load_module_configs(self):
+        module_config = {}
+        modules = self.app.modules.modules
+        for module_name in modules.keys():
+            module = modules[module_name]
+            conf = module.get_default_config()
+            module_config[module_name] = conf
+            self.logger.debug("Loading default config for module '%s': %s" % (module_name, str(conf)))
+        self.defaults["modules"] = module_config
+        self.config = self.merge_defaults(self.config)
+
     def load_default_keys(self):
         path = os.path.join(self.app.path, "config", self.default_keymap_filename)
         config = self.load_config_file(path)

--- a/suplemon/main.py
+++ b/suplemon/main.py
@@ -111,6 +111,9 @@ class App:
         self.modules = module_loader.ModuleLoader(self)
         self.modules.load()
 
+        # Load default module configs
+        self.config.load_module_configs()
+
         # Load themes
         self.themes = themes.ThemeLoader(self)
 

--- a/suplemon/suplemon_module.py
+++ b/suplemon/suplemon_module.py
@@ -138,6 +138,10 @@ class Module:
         """Set module options."""
         self.options = options
 
+    def get_default_config(self):
+        """Return module default config dict"""
+        return {}
+
     def is_runnable(self):
         cls_method = getattr(Module, "run")
         return self.run.__module__ != cls_method.__module__


### PR DESCRIPTION
This allows modules which provide a method called get_default_config() to return a dict of own default settings which will then be merged into the global config as config["modules"][$module_name].
This can then be modified by a user config using the same path.

The idea is that modules can provide their own default config without modifying defaults.json and still allow the user to modify that config which can be useful for e.g. out-of-tree modules.
It also prevents clutter of defaults.json with config options for modules which are not actually used by the user.

Another possible use case would be to have every module expose a default boolean config option like "enabled" which can default to false. Then the user can manually enable modules which are more of special case modules and does not have to delete or move the module file itself.

~~Instead of testing if the module provides a get_default_config() function it could also be implemented in the module base class.~~

Things to do:
- [x] ~~add get_default_config() as stub inside module base class~~
- [x] ~~rebase on dev~~
- [x] ~~squash~~