### PR TITLE
viewer.py: Highlight current line(s)

### DIFF
--- a/suplemon/config/defaults.json
+++ b/suplemon/config/defaults.json
@@ -102,6 +102,8 @@
         "show_tab_indicators": true,
         // Tab indicator charatrer
         "tab_indicator_character": "\u203A",
+        // Highlight current line(s)
+        "highlight_current_line": true,
         // Line numbering
         "show_line_nums": true,
         // Naive line highlighting

--- a/suplemon/viewer.py
+++ b/suplemon/viewer.py
@@ -313,8 +313,16 @@ class BaseViewer:
             lnum = i + self.y_scroll
             if lnum >= len(self.lines):  # Make sure we have a line to show
                 break
+
             # Get line for current row
             line = self.lines[lnum]
+
+            attribs = None
+            if self.config["highlight_current_line"] and self._is_current_line(i):
+                # Highlight current line by adding bold to background attribute set
+                attribs = self.window.getbkgd()
+                self.window.bkgdset(" ", attribs | curses.A_BOLD)
+
             if self.config["show_line_nums"]:
                 curs_color = curses.color_pair(line.number_color)
                 padded_num = str(lnum+1).zfill(self.line_offset()-1)
@@ -326,7 +334,17 @@ class BaseViewer:
             except:
                 self.logger.error("Failed rendering line #{0} @{1} DATA:'{2}'!".format(lnum+1, pos, line),
                                   exc_info=True)
+            if attribs is not None:
+                # Restore background attribute set
+                self.window.bkgdset(" ", attribs)
+
         self.render_cursors()
+
+    def _is_current_line(self, y):
+        for cursor in self.cursors:
+            if cursor.y - self.y_scroll == y:
+                return True
+        return False
 
     def render_line_contents(self, line, pos, x_offset, max_len):
         """Render the contents of a line to the screen


### PR DESCRIPTION
Highlight current line(s). A line is treated as current if there is at least one cursor.
This commit sets the default config value for this feature to true. I am happy to change the default to false if desired.
This PR should automerge with PR #215 without producing conflicts.