### PR TITLE
Simple xterm-256color imitation for curses

### DIFF
--- a/suplemon/config/defaults.json
+++ b/suplemon/config/defaults.json
@@ -19,7 +19,10 @@
         // How long curses will wait to detect ESC key
         "escdelay": 50,
         // Whether to use special unicode symbols for decoration
-        "use_unicode_symbols": true
+        "use_unicode_symbols": true,
+        // If your $TERM ends in -256color and this is true, 'xterm-256color'
+        // will be used instead, working around an issue with curses.
+        "imitate_256color": false
     },
     // Editor settings
     "editor": {

--- a/suplemon/ui.py
+++ b/suplemon/ui.py
@@ -120,6 +120,13 @@ class UI:
         global curses
         # Set ESC detection time
         os.environ["ESCDELAY"] = str(self.app.config["app"]["escdelay"])
+        termenv = os.environ["TERM"]
+        if termenv.endswith("-256color") and self.app.config["app"].get("imitate_256color"):
+            # Curses doesn't recognize 'screen-256color' or 'tmux-256color' as 256-color terminals.
+            # These terminals all seem to be identical to xterm-256color, which is recognized.
+            # Since this might have other consequences it's hidden behind a config flag.
+            self.logger.debug("Changing terminal from '{0}' to 'xterm-256color'".format(termenv))
+            os.environ["TERM"] = "xterm-256color"
         # Now import curses, otherwise ESCDELAY won't have any effect
         import curses
         self.logger.debug("Loaded curses {0}".format(curses.version.decode()))


### PR DESCRIPTION
Curses doesn't recognize `screen-256color` as a 256-color terminal; this commit introduces a new configuration field (`app["imitate_256color"]`) which looks for `$TERM` values ending in `-256color` and changes it to `xterm-256color` before curses is loaded.

I considered having a `terminal_override` config value instead but this seems a little more elegant and lets you use multiple terminals, some without 256-color support, without changing your suplemon configuration.

Before this patch, `TERM=screen-256color` leads to:

```
2018-05-04 20:45:46,967 - suplemon.ui - WARNING - Enhanced colors not supported. You could try 'export TERM=xterm-256color'.
```

With this patch, `TERM=screen-256color`, and `app["imitate_256color"] = True`, the message does not appear.

Not sure what the process for suggesting a new configuration key is - I'm deliberately using `.get` so folks don't get errors when using older configuration files that do not have `imitate_256color` set.