### PR TITLE
Ctrl+H toggles help

### DIFF
--- a/suplemon/file.py
+++ b/suplemon/file.py
@@ -22,6 +22,7 @@ class File:
         self.opened = time.time()  # Time of last open
         self.editor = None
         self.writable = True
+        self.is_help = False
 
     def _path(self):
         """Get the full path of the file."""

--- a/suplemon/main.py
+++ b/suplemon/main.py
@@ -363,8 +363,8 @@ class App:
         if self.get_file().is_help:
             self.close_file()
         else:
-            idx = next((i for i,f in enumerate(self.files) if f.is_help), -1)
-            if idx==-1:
+            idx = next((i for i, f in enumerate(self.files) if f.is_help), -1)
+            if idx == -1:
                 f = self.default_file()
                 from . import help
                 f.set_data(help.help_text)

--- a/suplemon/main.py
+++ b/suplemon/main.py
@@ -355,12 +355,16 @@ class App:
     ###########################################################################
 
     def help(self):
-        """Open a new file with help text."""
-        f = self.default_file()
-        from . import help
-        f.set_data(help.help_text)
-        self.files.append(f)
-        self.switch_to_file(self.last_file_index())
+        """Open a new file with help text, or close it if it is open."""
+        if self.get_file().is_help:
+            self.close_file()
+        else:
+            f = self.default_file()
+            from . import help
+            f.set_data(help.help_text)
+            f.is_help = True
+            self.files.append(f)
+            self.switch_to_file(self.last_file_index())
 
     def new_file(self, path=None):
         """Open a new empty file.

--- a/suplemon/main.py
+++ b/suplemon/main.py
@@ -355,16 +355,23 @@ class App:
     ###########################################################################
 
     def help(self):
-        """Open a new file with help text, or close it if it is open."""
+        """Toggle the help document.
+        - If current document is help, close it.
+        - Otherwise, if help is open, switch to it.
+        - Otherwise, open a new file with help text.
+        """
         if self.get_file().is_help:
             self.close_file()
         else:
-            f = self.default_file()
-            from . import help
-            f.set_data(help.help_text)
-            f.is_help = True
-            self.files.append(f)
-            self.switch_to_file(self.last_file_index())
+            idx = next((i for i,f in enumerate(self.files) if f.is_help), -1)
+            if idx==-1:
+                f = self.default_file()
+                from . import help
+                f.set_data(help.help_text)
+                f.is_help = True
+                self.files.append(f)
+                idx = self.last_file_index()
+            self.switch_to_file(idx)
 
     def new_file(self, path=None):
         """Open a new empty file.


### PR DESCRIPTION
Solves this issue: https://github.com/richrd/suplemon/issues/250
Ctrl+H toggles the help instead of always opening a new tab. The logic is this when pressing Ctrl+H:

- If the current file is help, close it.
- Otherwise, open new help file.

We can also extend it to match this behavior if you want, so that at most 1 help is open:

- If the current file is help, close it.
- Otherwise, if there is an open help, bring it to front.
- Otherwise open new help file.
